### PR TITLE
video witdth temp fix

### DIFF
--- a/docroot/themes/gavias_vinor/includes/template.functions.php
+++ b/docroot/themes/gavias_vinor/includes/template.functions.php
@@ -29,7 +29,7 @@ function gavias_vinor_preprocess_node(&$variables) {
                $autoembed = new AutoEmbed();
                $iframe = $autoembed->parse($field_post_embed->value);
 
-                //iframe was getting the height from source, i.e vimeo, youtube etc.
+               //iframe was getting dimensions from source's container not fitting ours.
                $frameParts = explode(" ", $iframe);
                foreach($frameParts as $index => $value){
                   if(strpos($value, "width=") !== false) {

--- a/docroot/themes/gavias_vinor/includes/template.functions.php
+++ b/docroot/themes/gavias_vinor/includes/template.functions.php
@@ -28,6 +28,18 @@ function gavias_vinor_preprocess_node(&$variables) {
             if(isset($field_post_embed->value) && $field_post_embed->value){
                $autoembed = new AutoEmbed();
                $iframe = $autoembed->parse($field_post_embed->value);
+
+                //iframe was getting the height from source, i.e vimeo, youtube etc.
+               $frameParts = explode(" ", $iframe);
+               foreach($frameParts as $index => $value){
+                  if(strpos($value, "width=") !== false) {
+                      $frameParts[$index] = 'width=100%';
+                  } elseif(strpos($value, "height=") !== false){
+                      $frameParts[$index] = 'height=100%';
+                  }
+               }
+               $iframe = implode(" ", $frameParts);
+
             }else{
                $iframe = '';
                $post_format = 'standard';


### PR DESCRIPTION
Copies the width & height from the Video's source, i.e. youtube, vimeo. This width is according to their container and shorter than ours. Giving width and height 100% seems to take up all of the allowed space in our container.

Emailed authors about the bug, requesting fix. 
Until then here is a temp fix.